### PR TITLE
Only install TailScale if it isn't already installed

### DIFF
--- a/orb.yaml
+++ b/orb.yaml
@@ -20,20 +20,25 @@ commands:
         default: "1.16.1"
     steps:
       - run:
-          name: "Download tailscale"
+          name: "Download tailscale if not installed"
           command: |
-            VERSION=<< parameters.tailscale-version >>
-            MINOR=$(echo << parameters.tailscale-version >> | awk -F '.' {'print $2'})
-            if [ $((MINOR % 2)) -eq 0 ]; then
-              URL="https://pkgs.tailscale.com/stable/tailscale_${VERSION}_amd64.tgz"
+            if ! command -v tailscale --version >/dev/null 2>&1; then
+              echo "Tailscale is not installed, installing..."
+              VERSION=<< parameters.tailscale-version >>
+              MINOR=$(echo << parameters.tailscale-version >> | awk -F '.' {'print $2'})
+              if [ $((MINOR % 2)) -eq 0 ]; then
+                URL="https://pkgs.tailscale.com/stable/tailscale_${VERSION}_amd64.tgz"
+              else
+                URL="https://pkgs.tailscale.com/unstable/tailscale_${VERSION}_amd64.tgz"
+              fi
+              curl $URL -o tailscale.tgz
+              tar -C ${HOME} -xzf tailscale.tgz
+              rm tailscale.tgz
+              TSPATH=${HOME}/tailscale_${VERSION}_amd64
+              sudo mv "${TSPATH}/tailscale" "${TSPATH}/tailscaled" /usr/bin
             else
-              URL="https://pkgs.tailscale.com/unstable/tailscale_${VERSION}_amd64.tgz"
+              echo "Tailscale is already installed"
             fi
-            curl $URL -o tailscale.tgz
-            tar -C ${HOME} -xzf tailscale.tgz
-            rm tailscale.tgz
-            TSPATH=${HOME}/tailscale_${VERSION}_amd64
-            sudo mv "${TSPATH}/tailscale" "${TSPATH}/tailscaled" /usr/bin
       - run:
           name: "Run tailscale"
           background: true


### PR DESCRIPTION
Closes https://github.com/threecommaio/circleci-tailscale/issues/1

Checks if the `tailscale` command is in the `PATH` and if it is skips the install step.