### PR TITLE
Make proxy address configurable via a parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ jobs:
       tailscale-auth-key:
         type: env_var_name
         default: TAILSCALE_AUTH_KEY
+      tailscale-proxy-address:
+        type: string
+        default: localhost
     steps:
       - checkout
       - circleci-tailscale/connect
@@ -62,7 +65,8 @@ jobs:
 
 ## Parameters
 
-| Parameter          | Description                                              | Default Value |
-| ------------------ | -------------------------------------------------------- | ------------- |
-| tailscale-auth-key | Your Tailscale authentication key, from the admin panel. |               |
-| tailscale-version  | Tailscale version to use.                                | 1.20.4        |
+| Parameter               | Description                                              | Default Value |
+| ----------------------- | -------------------------------------------------------- | ------------- |
+| tailscale-auth-key      | Your Tailscale authentication key, from the admin panel. |               |
+| tailscale-proxy-address | Proxy address where tailscale should listen.             | localhost     |
+| tailscale-version       | Tailscale version to use.                                | 1.20.4        |

--- a/orb.yaml
+++ b/orb.yaml
@@ -14,6 +14,10 @@ commands:
         type: env_var_name
         description: Your Tailscale authentication key, from the admin panel.
         default: TAILSCALE_AUTH_KEY
+      tailscale-proxy-address:
+        type: string
+        description: Proxy address where tailscale should listen.
+        default: localhost
       tailscale-version:
         type: string
         description: Tailscale version to use.
@@ -43,7 +47,7 @@ commands:
           name: "Run tailscale"
           background: true
           command: |
-            tailscaled --tun=userspace-networking --outbound-http-proxy-listen=localhost:1054 --socks5-server=localhost:1055 --socket=/tmp/tailscaled.sock 2>~/tailscaled.log
+            tailscaled --tun=userspace-networking --outbound-http-proxy-listen=<< parameters.tailscale-proxy-address >>:1054 --socks5-server=<< parameters.tailscale-proxy-address >>:1055 --socket=/tmp/tailscaled.sock 2>~/tailscaled.log
       - run:
           name: "Auth tailscale"
           command: |
@@ -52,8 +56,8 @@ commands:
             do
               sleep 1
             done
-            echo "export ALL_PROXY=socks5h://localhost:1055/" >> $BASH_ENV
-            echo "export HTTP_PROXY=http://localhost:1054/" >> $BASH_ENV
-            echo "export HTTPS_PROXY=http://localhost:1054/" >> $BASH_ENV
-            echo "export http_proxy=http://localhost:1054/" >> $BASH_ENV
-            echo "export https_proxy=http://localhost:1054/" >> $BASH_ENV
+            echo "export ALL_PROXY=socks5h://<< parameters.tailscale-proxy-address >>:1055/" >> $BASH_ENV
+            echo "export HTTP_PROXY=http://<< parameters.tailscale-proxy-address >>:1054/" >> $BASH_ENV
+            echo "export HTTPS_PROXY=http://<< parameters.tailscale-proxy-address >>:1054/" >> $BASH_ENV
+            echo "export http_proxy=http://<< parameters.tailscale-proxy-address >>:1054/" >> $BASH_ENV
+            echo "export https_proxy=http://<< parameters.tailscale-proxy-address >>:1054/" >> $BASH_ENV


### PR DESCRIPTION
When running a docker-compose inside cci (with its own network), tailscale needs to know that it's not going to be reached via `localhost` or `127.0.0.1`. 

In my case, I chose to use `0.0.0.0` to make it reachable from anywhere.